### PR TITLE
Reenable akka-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ libraryDependencies ++= Seq(
   "com.github.pjfanning" %% "op-rabbit-core"        % opRabbitVersion,
   "com.github.pjfanning" %% "op-rabbit-play-json"   % opRabbitVersion,
   "com.github.pjfanning" %% "op-rabbit-json4s"      % opRabbitVersion,
-  "com.github.pjfanning" %% "op-rabbit-airbrake"    % opRabbitVersion
+  "com.github.pjfanning" %% "op-rabbit-airbrake"    % opRabbitVersion,
+  "com.github.pjfanning" %% "op-rabbit-akka-stream" % opRabbitVersion
 )
 ```
 
@@ -42,6 +43,7 @@ Supports Scala 2.13 and Scala 2.12.
 | op-rabbit-circe              | circe                    | 0.13.x      |
 | op-rabbit-json4s             | json4s                   | 3.6.x       |
 | op-rabbit-airbrake           | airbrake                 | 2.2.x       |
+| op-rabbit-akka-stream        | akka-stream              | 2.6.x       |
 
 #### op-rabbit 2.5.x and 2.4.x
 
@@ -105,6 +107,8 @@ Supports Scala 2.13 and Scala 2.12.
     - Report consumer exceptions to airbrake, using the
       [Airbrake](https://github.com/airbrake/airbrake-java) Java
       library.
+- `op-rabbit-akka-stream` [API](https://op-rabbit.github.io/docs/index.html#com.spingo.op_rabbit.stream.package)
+    - Process or publish messages using akka-stream. 
 
 ## Usage
 

--- a/addons/akka-stream/src/main/scala/com/spingo/op_rabbit/stream/MessagePublisherSink.scala
+++ b/addons/akka-stream/src/main/scala/com/spingo/op_rabbit/stream/MessagePublisherSink.scala
@@ -2,11 +2,8 @@ package com.spingo.op_rabbit.stream
 
 import com.spingo.op_rabbit._
 import com.spingo.op_rabbit.Message._
-import akka.stream.stage.GraphStage
-import akka.actor.{ActorRef, Props}
-import akka.actor.FSM
+import akka.actor.ActorRef
 import akka.pattern.ask
-import akka.stream.scaladsl.Sink
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 import com.timcharper.acked.AckedSink
@@ -15,7 +12,6 @@ import akka.stream._
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.GraphStageWithMaterializedValue
 import akka.stream.stage.InHandler
-import akka.stream.scaladsl.Flow
 import akka.util.Timeout
 
 
@@ -130,7 +126,7 @@ object MessagePublisherSink {
     @param rabbitControl An actor
     @param timeoutAfter The duration for which we'll wait for a message to be acked; note, timeouts and non-acknowledged messages will cause the upstream elements to fail. The sink will not throw an exception.
     */
-  def apply(rabbitControl: ActorRef, timeoutAfter: FiniteDuration = 30 seconds, qos: Int = 8): AckedSink[Message, Future[Unit]] = AckedSink {
+  def apply(rabbitControl: ActorRef, timeoutAfter: FiniteDuration = 30.seconds, qos: Int = 8): AckedSink[Message, Future[Unit]] = AckedSink {
     new MessagePublisherSink(rabbitControl, timeoutAfter, qos)
   }
 }

--- a/addons/akka-stream/src/test/scala/com/spingo/op_rabbit/stream/MessagePublisherSinkSpec.scala
+++ b/addons/akka-stream/src/test/scala/com/spingo/op_rabbit/stream/MessagePublisherSinkSpec.scala
@@ -2,7 +2,6 @@ package com.spingo.op_rabbit
 package stream
 
 import akka.actor._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink}
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.Envelope
@@ -10,6 +9,8 @@ import com.spingo.op_rabbit.Directives._
 import com.spingo.op_rabbit.helpers.RabbitTestHelpers
 import com.timcharper.acked.AckedSource
 import com.spingo.scoped_fixtures.ScopedFixtures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Try}
@@ -26,7 +27,6 @@ class MessagePublisherSinkSpec extends AnyFunSpec with Matchers with ScopedFixtu
   }
 
   trait RabbitFixtures {
-    implicit val materializer = ActorMaterializer()
     val exceptionReported = Promise[Boolean]
     implicit val errorReporting = new RabbitErrorLogging {
       def apply(name: String, message: String, exception: Throwable, consumerTag: String, envelope: Envelope, properties: BasicProperties, body: Array[Byte]): Unit = {

--- a/addons/akka-stream/src/test/scala/com/spingo/op_rabbit/stream/RabbitSourceSpec.scala
+++ b/addons/akka-stream/src/test/scala/com/spingo/op_rabbit/stream/RabbitSourceSpec.scala
@@ -1,15 +1,16 @@
 package com.spingo.op_rabbit
 package stream
 
-import akka.actor._
-import akka.stream.{ActorAttributes, ActorMaterializer, ActorMaterializerSettings, Supervision}
+import akka.stream.{ActorAttributes, Supervision}
 import akka.stream.scaladsl.{Keep, Sink}
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.Envelope
 import com.spingo.op_rabbit.Directives._
 import com.spingo.op_rabbit.helpers.{DeleteQueue, RabbitTestHelpers}
 import com.spingo.scoped_fixtures.ScopedFixtures
-import com.timcharper.acked.{AckedSink, AckedSource}
+import com.timcharper.acked.AckedSink
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
@@ -27,7 +28,6 @@ class RabbitSourceSpec extends AnyFunSpec with Matchers with ScopedFixtures with
 
   trait RabbitFixtures {
     implicit val executionContext = ExecutionContext.global
-    implicit val materializer = ActorMaterializer()
     val exceptionReported = Promise[Boolean]
     implicit val errorReporting = new RabbitErrorLogging {
       def apply(name: String, message: String, exception: Throwable, consumerTag: String, envelope: Envelope, properties: BasicProperties, body: Array[Byte]): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val `op-rabbit` = (project in file(".")).
     description := "The opinionated Rabbit-MQ plugin",
     name := "op-rabbit").
   dependsOn(core).
-  aggregate(core, `play-json`, airbrake, json4s, `spray-json`, circe)
+  aggregate(core, `play-json`, airbrake, `akka-stream`, json4s, `spray-json`, circe)
 
 
 lazy val core = (project in file("./core")).
@@ -122,18 +122,20 @@ lazy val airbrake = (project in file("./addons/airbrake/")).
     libraryDependencies += "io.airbrake" % "airbrake-java" % "2.2.8").
   dependsOn(core)
 
-//lazy val `akka-stream` = (project in file("./addons/akka-stream")).
-//  settings(commonSettings: _*).
-//  settings(
-//    name := "op-rabbit-akka-stream",
-//    libraryDependencies ++= Seq(
-//      "com.timcharper"    %% "acked-streams" % "2.1.1",
-//      "com.typesafe.akka" %% "akka-stream" % akkaVersion),
-//    unmanagedResourceDirectories in Test ++= Seq(
-//      file(".").getAbsoluteFile / "core" / "src" / "test" / "resources"),
-//    unmanagedSourceDirectories in Test ++= Seq(
-//      file(".").getAbsoluteFile / "core" / "src" / "test" / "scala" / "com" / "spingo" / "op_rabbit" / "helpers")).
-//  dependsOn(core)
+lazy val `akka-stream` = (project in file("./addons/akka-stream")).
+  settings(commonSettings: _*).
+  settings(
+    name := "op-rabbit-akka-stream",
+    resolvers += "jitpack" at "https://jitpack.io",
+    libraryDependencies ++= Seq(
+      //"com.timcharper"    %% "acked-streams" % "2.1.1",
+      "com.github.timcharper.acked-stream" %% "acked-streams" % "0faf9027c9",
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion),
+    unmanagedResourceDirectories in Test ++= Seq(
+      file(".").getAbsoluteFile / "core" / "src" / "test" / "resources"),
+    unmanagedSourceDirectories in Test ++= Seq(
+      file(".").getAbsoluteFile / "core" / "src" / "test" / "scala" / "com" / "spingo" / "op_rabbit" / "helpers")).
+  dependsOn(core)
 
 lazy val circe = (project in file("./addons/circe")).
   settings(commonSettings: _*).


### PR DESCRIPTION
Reenable akka-stream module with the fix provided by @carstenlenz that makes the module compile with akka 2.6. For now, this is using a custom version of `acked-stream` library, but built from it's main repository (the PR has been accepted to master, but a new version not released yet) via jitpack.

